### PR TITLE
テストが通るようにした

### DIFF
--- a/test/02_object_model/test_hierarchy.rb
+++ b/test/02_object_model/test_hierarchy.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'hierarchy'
 
 class TestHierarchy < MiniTest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,2 @@
 require 'minitest/autorun'
-require "minitest/reporters"
-Minitest::Reporters.use!
 Dir.glob(File.expand_path("../../[0-9]*", __FILE__)).each { |path| $LOAD_PATH.unshift(path) }


### PR DESCRIPTION
Minitest::Reporters とtest_helperのpath関連でテストが通らなかったため、それらを修正してテストが通るようにした。